### PR TITLE
[P2] Enabled support for abandoned carts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The store should now be connected and Engagement Cloud will start syncing custom
 For more detailed information on installation, find it at (https://support.dotdigital.com/hc/en-gb/categories/201643998-Integrations)
 
 ## Release Notes
+# 1.1.0
+ * Abandoned cart support  
+ 
 # 1.0.0
 * First release
 * Sync WooCommerce customers

--- a/engagement-cloud.php
+++ b/engagement-cloud.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name:       dotdigital Engagement Cloud for WooCommerce
  * Description:       Engagement Cloud Integration for WooCommerce ecommerce platform.
- * Version:           1.0.0
+ * Version:           1.1.0
  * Author:            dotdigital
  * Author URI:        https://www.dotdigital.com/
  * License:           MIT

--- a/includes/class-engagement-cloud-activator.php
+++ b/includes/class-engagement-cloud-activator.php
@@ -98,21 +98,5 @@ class Engagement_Cloud_Activator {
 		}
 
 		wp_remote_post( "$this->callback_url/e/woocommerce/enable?pluginid=$plugin_id" );
-		
-		$this->enable_a2c();
-	}
-	
-	/**
-	 * Set the options so Api2Cart cam know that modified and created date queries are supported
-	 *
-	 * @since    1.1.0
-	 */
-	private function enable_a2c(){
-	    if(!get_option('webhook_helper_version')){
-	        update_option('webhook_helper_version', '1.0.1', false);
-	    }
-	    if(!get_option('webhook_helper_active')) {
-	        update_option('webhook_helper_active', true, false);
-	    }
 	}
 }

--- a/includes/class-engagement-cloud-activator.php
+++ b/includes/class-engagement-cloud-activator.php
@@ -98,5 +98,21 @@ class Engagement_Cloud_Activator {
 		}
 
 		wp_remote_post( "$this->callback_url/e/woocommerce/enable?pluginid=$plugin_id" );
+		
+		$this->enable_a2c();
+	}
+	
+	/**
+	 * Set the options so Api2Cart cam know that modified and created date queries are supported
+	 *
+	 * @since    1.1.0
+	 */
+	private function enable_a2c(){
+	    if(!get_option('webhook_helper_version')){
+	        update_option('webhook_helper_version', '1.0.1', false);
+	    }
+	    if(!get_option('webhook_helper_active')) {
+	        update_option('webhook_helper_active', true, false);
+	    }
 	}
 }

--- a/includes/class-engagement-cloud-loader.php
+++ b/includes/class-engagement-cloud-loader.php
@@ -123,7 +123,7 @@ class Engagement_Cloud_Loader {
 			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
 		}
 		
-		$this->enable_a2c();
+		$this->enable_api2cart();
 	}
 	
 	/**
@@ -131,7 +131,7 @@ class Engagement_Cloud_Loader {
 	 *
 	 * @since    1.1.0
 	 */
-	private function enable_a2c(){
+	private function enable_api2cart(){
 	    if(!get_option('webhook_helper_version')){
 	        update_option('webhook_helper_version', '1.0.1', false);
 	    }

--- a/includes/class-engagement-cloud-loader.php
+++ b/includes/class-engagement-cloud-loader.php
@@ -122,5 +122,21 @@ class Engagement_Cloud_Loader {
 		foreach ( $this->actions as $hook ) {
 			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
 		}
+		
+		$this->enable_a2c();
+	}
+	
+	/**
+	 * Set the options so Api2Cart cam know that modified and created date queries are supported
+	 *
+	 * @since    1.1.0
+	 */
+	private function enable_a2c(){
+	    if(!get_option('webhook_helper_version')){
+	        update_option('webhook_helper_version', '1.0.1', false);
+	    }
+	    if(!get_option('webhook_helper_active')) {
+	        update_option('webhook_helper_active', true, false);
+	    }
 	}
 }

--- a/includes/class-engagement-cloud-loader.php
+++ b/includes/class-engagement-cloud-loader.php
@@ -127,16 +127,12 @@ class Engagement_Cloud_Loader {
 	}
 	
 	/**
-	 * Set the options so Api2Cart cam know that modified and created date queries are supported
+	 * Set the options so Api2Cart can know that modified and created date queries are supported
 	 *
 	 * @since    1.1.0
 	 */
 	private function enable_api2cart(){
-	    if(!get_option('webhook_helper_version')){
-	        update_option('webhook_helper_version', '1.0.1', false);
-	    }
-	    if(!get_option('webhook_helper_active')) {
+	        update_option('webhook_helper_version', '1.1.0', false);
 	        update_option('webhook_helper_active', true, false);
-	    }
 	}
 }

--- a/includes/class-engagement-cloud-loader.php
+++ b/includes/class-engagement-cloud-loader.php
@@ -123,7 +123,7 @@ class Engagement_Cloud_Loader {
 			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
 		}
 		
-		$this->enable_api2cart();
+		$this->enable_abandoned_cart();
 	}
 	
 	/**
@@ -131,7 +131,7 @@ class Engagement_Cloud_Loader {
 	 *
 	 * @since    1.1.0
 	 */
-	private function enable_api2cart(){
+	private function enable_abandoned_cart(){
 	        update_option('webhook_helper_version', '1.1.0', false);
 	        update_option('webhook_helper_active', true, false);
 	}

--- a/includes/class-engagement-cloud.php
+++ b/includes/class-engagement-cloud.php
@@ -239,6 +239,11 @@ class Engagement_Cloud {
 
 		$this->loader->add_action( 'woocommerce_checkout_after_customer_details', $plugin_woocommerce, 'engagement_cloud_render_checkout_marketing_checkbox', 5 );
 		$this->loader->add_action( 'woocommerce_checkout_order_processed', $plugin_woocommerce, 'engagement_cloud_handle_checkout_marketing_checkbox', 5 );
+		
+		$this->loader->add_action( 'woocommerce_update_cart_action_cart_updated', $plugin_woocommerce, 'api2cart_cart_updated', 5 );
+		$this->loader->add_action( 'woocommerce_add_to_cart', $plugin_woocommerce, 'api2cart_cart_updated', 5 );
+		$this->loader->add_action( 'woocommerce_cart_item_removed', $plugin_woocommerce, 'api2cart_cart_updated', 5 );
+		$this->loader->add_action( 'woocommerce_cart_item_restored', $plugin_woocommerce, 'api2cart_cart_updated', 5 );
 	}
 
 	/**

--- a/includes/class-engagement-cloud.php
+++ b/includes/class-engagement-cloud.php
@@ -240,10 +240,10 @@ class Engagement_Cloud {
 		$this->loader->add_action( 'woocommerce_checkout_after_customer_details', $plugin_woocommerce, 'engagement_cloud_render_checkout_marketing_checkbox', 5 );
 		$this->loader->add_action( 'woocommerce_checkout_order_processed', $plugin_woocommerce, 'engagement_cloud_handle_checkout_marketing_checkbox', 5 );
 		
-		$this->loader->add_action( 'woocommerce_update_cart_action_cart_updated', $plugin_woocommerce, 'api2cart_cart_updated', 5 );
-		$this->loader->add_action( 'woocommerce_add_to_cart', $plugin_woocommerce, 'api2cart_cart_updated', 5 );
-		$this->loader->add_action( 'woocommerce_cart_item_removed', $plugin_woocommerce, 'api2cart_cart_updated', 5 );
-		$this->loader->add_action( 'woocommerce_cart_item_restored', $plugin_woocommerce, 'api2cart_cart_updated', 5 );
+		$this->loader->add_action( 'woocommerce_update_cart_action_cart_updated', $plugin_woocommerce, 'cart_updated', 5 );
+		$this->loader->add_action( 'woocommerce_add_to_cart', $plugin_woocommerce, 'cart_updated', 5 );
+		$this->loader->add_action( 'woocommerce_cart_item_removed', $plugin_woocommerce, 'cart_updated', 5 );
+		$this->loader->add_action( 'woocommerce_cart_item_restored', $plugin_woocommerce, 'cart_updated', 5 );
 	}
 
 	/**

--- a/includes/platforms/class-engagement-cloud-woocommerce.php
+++ b/includes/platforms/class-engagement-cloud-woocommerce.php
@@ -128,5 +128,6 @@ class Engagement_Cloud_WooCommerce {
 	        elseif ($itemsCount === 0) {
 	            delete_user_meta($user_id, $createdKey);
 	        }
+	    }
 	}
 }

--- a/includes/platforms/class-engagement-cloud-woocommerce.php
+++ b/includes/platforms/class-engagement-cloud-woocommerce.php
@@ -105,11 +105,11 @@ class Engagement_Cloud_WooCommerce {
 	}
 	
 	/**
-	 * Updates the modified cart date so Api2Cart can handle.
+	 * Updates the modified cart date.
 	 *
 	 * @since    1.1.0
 	 */
-	function api2cart_cart_updated() {
+	function cart_updated() {
 	    $woocommerce = WooCommerce::instance();
 	    $user_id = get_current_user_id() ?: $woocommerce->session->get_customer_id();
 	    $blog_id = get_current_blog_id();

--- a/includes/platforms/class-engagement-cloud-woocommerce.php
+++ b/includes/platforms/class-engagement-cloud-woocommerce.php
@@ -110,8 +110,10 @@ class Engagement_Cloud_WooCommerce {
 	 * @since    1.1.0
 	 */
 	function api2cart_cart_updated() {
-	    $user_id = get_current_user_id() ?: WooCommerce::instance()->session->get_customer_id();
+	    $woocommerce = WooCommerce::instance();
+	    $user_id = get_current_user_id() ?: $woocommerce->session->get_customer_id();
 	    $blog_id = get_current_blog_id();
+	    $itemsCount = count($woocommerce->cart->get_cart_contents());
 	    
 	    if (preg_match('/^[a-f0-9]{32}$/', $user_id) !== 1) {
 	        $updateTime = time();
@@ -123,6 +125,8 @@ class Engagement_Cloud_WooCommerce {
 	        if(get_user_meta($user_id, $createdKey, true) === '') {
 	            update_user_meta($user_id, $createdKey, $updateTime);
 	        }
-	    }
+	        elseif ($itemsCount === 0) {
+	            delete_user_meta($user_id, $createdKey);
+	        }
 	}
 }

--- a/includes/platforms/class-engagement-cloud-woocommerce.php
+++ b/includes/platforms/class-engagement-cloud-woocommerce.php
@@ -103,4 +103,26 @@ class Engagement_Cloud_WooCommerce {
 		}
 		update_user_meta( $user_id, $this->meta_key, $accepts_marketing );
 	}
+	
+	/**
+	 * Updates the modified cart date so Api2Cart can handle.
+	 *
+	 * @since    1.1.0
+	 */
+	function api2cart_cart_updated() {
+	    $user_id = get_current_user_id() ?: WooCommerce::instance()->session->get_customer_id();
+	    $blog_id = get_current_blog_id();
+	    
+	    if (preg_match('/^[a-f0-9]{32}$/', $user_id) !== 1) {
+	        $updateTime = time();
+	        $updatedKey = '_a2c_wh_cart_' . $blog_id . '_updated_gmt';
+	        $createdKey = '_a2c_wh_cart_' . $blog_id . '_created_gmt';
+	        
+	        update_user_meta($user_id, $updatedKey, $updateTime);
+	        
+	        if(get_user_meta($user_id, $createdKey, true) === '') {
+	            update_user_meta($user_id, $createdKey, $updateTime);
+	        }
+	    }
+	}
 }


### PR DESCRIPTION
This change let us use Api2cart queries to find carts based on modified and created date to enhance the connection with Engagement Cloud.

##How to test.
 - Replace the files in your plugin folder
 - Deactivate and reactivate the plugin (so the api2cart flags get loaded up)
 - Add/remove items to a cart.
 - Check in Api2Cart store that the abandoned list of orders have populated the created and modified dates and that they can be used in the query (`modified/created_from/to` format).