### PR TITLE
Remove define public hooks, fixes #14

### DIFF
--- a/includes/class-engagement-cloud.php
+++ b/includes/class-engagement-cloud.php
@@ -98,7 +98,6 @@ class Engagement_Cloud {
 		$this->load_dependencies();
 		$this->set_locale();
 		$this->define_admin_hooks();
-		$this->define_public_hooks();
 
 		$this->define_validation_hooks();
 		$this->define_woocommerce_hooks();


### PR DESCRIPTION
The plugin outputs empty CSS and JS files in the DOM. I've retained the structure (it's possible we'll need this in the future) but removed the call that enqueues the scripts.